### PR TITLE
fix: ensure BS-RoFormer installs

### DIFF
--- a/suno_ai_postpro_pipeline.py
+++ b/suno_ai_postpro_pipeline.py
@@ -41,9 +41,11 @@
 %cd ..
 
 # 4. Install Python packages
-!pip install --quiet \
-    bs_roformer \
-    pedalboard \
+# Upgrade core packaging tools first to avoid metadata build errors
+!pip install --upgrade pip==24.0 setuptools wheel
+!pip install --quiet --break-system-packages \
+    BS-RoFormer \
+    "pedalboard>=0.8.6" \
     pyloudnorm \
     matchering==2.0.6 \
     soundfile \

--- a/suno_ai_postpro_pipeline_gdrive.py
+++ b/suno_ai_postpro_pipeline_gdrive.py
@@ -49,9 +49,11 @@ drive.mount('/content/drive')
 %cd ..
 
 # 4. Install Python packages
-!pip install --quiet \
-    bs_roformer \
-    pedalboard \
+# Upgrade core packaging tools first to avoid metadata build errors
+!pip install --upgrade pip==24.0 setuptools wheel
+!pip install --quiet --break-system-packages \
+    BS-RoFormer \
+    "pedalboard>=0.8.6" \
     pyloudnorm \
     matchering==2.0.6 \
     soundfile \


### PR DESCRIPTION
## Summary
- upgrade packaging tools during environment setup
- install BS-RoFormer from the correct package name and set minimum pedalboard version

## Testing
- `python -m py_compile suno_ai_postpro_pipeline.py suno_ai_postpro_pipeline_gdrive.py`


------
https://chatgpt.com/codex/tasks/task_e_68961ce87eb08330a7dc2a050234d674