### PR TITLE
Add Colab setup and sample pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,31 @@
+
 # Auto Mixing Toolkit
 
-This repository provides a minimal library, command line tools and a demo notebook
-for automatic music mixing.
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/FusinKoo/Jules-Test-02/blob/main/notebooks/demo.ipynb)
+
+This repository provides a minimal library, command line tools and a demo notebook for automatic music mixing.
 
 ## Structure
 
 ```
-/env/               # Conda environments for CPU and GPU
 /mix/               # Reusable mixing library
 /scripts/           # Command line interfaces
 /tests/smoke/       # Smoke tests (stems generated at runtime)
 /notebooks/         # Demonstration notebook
 ```
 
-## Environment
+## Colab
 
-Install system dependencies:
+Open the notebook via the badge above. The first cell installs system and Python dependencies (including GPU support if available). The second cell generates short sine‑wave stems and mixes them using `scripts/mix_cli.py`.
 
-```
-apt-get install $(cat apt.txt)
-```
+## Command line
 
-Create a conda environment:
+Install system dependency and Python packages:
 
 ```
-conda env create -f env/environment.cpu.yml
+apt-get -y install ffmpeg
+pip install -r requirements-colab-cpu.txt  # or requirements-colab-gpu.txt
 ```
-
-For GPUs use `env/environment.gpu.yml`.
-
-## Usage
 
 Mix stems located in a folder:
 
@@ -37,8 +33,7 @@ Mix stems located in a folder:
 python scripts/mix_cli.py /path/to/input /path/to/output
 ```
 
-Input stems are expected as `vocals.wav`, `drums.wav`, `bass.wav` and `other.wav`.
-Outputs are written to the output directory:
+Input stems are expected as `vocals.wav`, `drums.wav`, `bass.wav` and `other.wav`. Outputs are written to the output directory:
 - `mix.wav` – the mixed audio
 - `mix_lufs.txt` – measured loudness
 - `report.json` – gain applied to each track
@@ -48,5 +43,5 @@ Outputs are written to the output directory:
 Run the smoke test which generates 5‑second stems and mixes them:
 
 ```
-pytest tests/smoke/test_mix.py
+PYTHONPATH=. pytest tests/smoke/test_mix.py
 ```

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -3,36 +3,48 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": [
-    "# If running in Colab, install conda\n",
-    "try:\n",
-    "    import condacolab\n",
-    "    condacolab.install()\n",
-    "except Exception:\n",
-    "    pass"
-   ],
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "import os, subprocess, sys\n",
+    "gpu = subprocess.run('nvidia-smi', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0\n",
+    "req = 'requirements-colab-gpu.txt' if gpu else 'requirements-colab-cpu.txt'\n",
+    "subprocess.run(['apt-get','-y','update'], check=True)\n",
+    "subprocess.run(['apt-get','-y','install','ffmpeg'], check=True)\n",
+    "subprocess.run([sys.executable,'-m','pip','install','-r',req], check=True)\n",
+    "if gpu:\n",
+    "    subprocess.run([sys.executable,'-m','pip','install','torch','torchaudio','torchvision','--index-url','https://download.pytorch.org/whl/cu121'], check=True)\n",
+    "else:\n",
+    "    subprocess.run([sys.executable,'-m','pip','install','torch','torchaudio','torchvision','--index-url','https://download.pytorch.org/whl/cpu'], check=True)\n"
+   ]
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": [
-    "import torch\n",
-    "print('Using device', 'cuda' if torch.cuda.is_available() else 'cpu')"
-   ],
    "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
+   "outputs": [],
    "source": [
-    "from mix import process\n",
-    "process('../tests/smoke/input', 'demo_output')"
-   ],
-   "execution_count": null,
-   "outputs": []
+    "import math, wave, array, subprocess, os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "def _write_tone(path, freq, duration=5, sr=44100):\n",
+    "    t = [math.sin(2*math.pi*freq*i/sr) for i in range(int(duration*sr))]\n",
+    "    ints = array.array('h', [int(max(-1.0,min(1.0,x))*32767) for x in t])\n",
+    "    path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    with wave.open(str(path), 'wb') as wf:\n",
+    "        wf.setnchannels(1); wf.setsampwidth(2); wf.setframerate(sr); wf.writeframes(ints.tobytes())\n",
+    "\n",
+    "def make_demo(directory):\n",
+    "    freqs={'vocals':440,'drums':220,'bass':110,'other':330}\n",
+    "    for name,f in freqs.items():\n",
+    "        _write_tone(directory / f'{name}.wav', f)\n",
+    "\n",
+    "inp = Path('demo_stems')\n",
+    "out = Path('demo_output')\n",
+    "make_demo(inp)\n",
+    "subprocess.run([sys.executable, 'scripts/mix_cli.py', str(inp), str(out)], check=True)\n",
+    "print('Mixed files:', os.listdir(out))\n"
+   ]
   }
  ],
  "metadata": {

--- a/requirements-colab-cpu.txt
+++ b/requirements-colab-cpu.txt
@@ -1,0 +1,6 @@
+numpy<2.1
+numba>=0.57,<0.60
+librosa==0.10.2.post1
+soundfile>=0.12
+audioread>=3.0
+tqdm

--- a/requirements-colab-gpu.txt
+++ b/requirements-colab-gpu.txt
@@ -1,0 +1,6 @@
+numpy<2.1
+numba>=0.57,<0.60
+librosa==0.10.2.post1
+soundfile>=0.12
+audioread>=3.0
+tqdm


### PR DESCRIPTION
## Summary
- pin audio dependencies for Colab in separate CPU/GPU requirement files
- add Colab notebook bootstrap cell that installs ffmpeg, requirements, and torch packages based on GPU availability
- document Colab and CLI usage with an "Open in Colab" badge and simplified instructions

## Testing
- `PYTHONPATH=. pytest tests/smoke/test_mix.py`

------
https://chatgpt.com/codex/tasks/task_e_68966d9a94008330a9491714127d70c7