### PR TITLE
Pin Colab CPU/GPU dependency versions

### DIFF
--- a/requirements-colab-cpu.txt
+++ b/requirements-colab-cpu.txt
@@ -1,6 +1,11 @@
-numpy<2.1
-numba>=0.57,<0.60
+--index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://pypi.org/simple
+torch==2.1.0+cpu
+torchaudio==2.1.0+cpu
+torchvision==0.16.0+cpu
+numpy==1.26.4
+numba==0.59.1
 librosa==0.10.2.post1
-soundfile>=0.12
-audioread>=3.0
-tqdm
+soundfile==0.12.1
+audioread==3.0.1
+tqdm==4.66.4

--- a/requirements-colab-gpu.txt
+++ b/requirements-colab-gpu.txt
@@ -1,6 +1,11 @@
-numpy<2.1
-numba>=0.57,<0.60
+--index-url https://download.pytorch.org/whl/cu121
+--extra-index-url https://pypi.org/simple
+torch==2.1.0+cu121
+torchaudio==2.1.0+cu121
+torchvision==0.16.0+cu121
+numpy==1.26.4
+numba==0.59.1
 librosa==0.10.2.post1
-soundfile>=0.12
-audioread>=3.0
-tqdm
+soundfile==0.12.1
+audioread==3.0.1
+tqdm==4.66.4


### PR DESCRIPTION
## Summary
- Pin torch, torchaudio, and torchvision to matching versions for CPU and GPU Colab profiles
- Lock core audio dependencies (numpy, numba, librosa, soundfile, audioread, tqdm) with explicit versions

## Testing
- `PYTHONPATH=. pytest tests/smoke/test_mix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68968625327c8330b05728257ff4ad92