### PR TITLE
Add deterministic utilities and CPU/GPU alignment test

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,17 @@ Run the smoke test which generates 5‑second stems and mixes them:
 ```
 PYTHONPATH=. pytest tests/smoke/test_mix.py
 ```
+
+## Deterministic runs
+
+Use the helper in `mix.deterministic` to reduce run‑to‑run variation across
+CPU and GPU backends. The command line accepts a seed which enables
+deterministic flags for NumPy, PyTorch and cuDNN:
+
+```
+python scripts/mix_cli.py input_dir output_dir --seed 0
+```
+
+This sets random seeds, fixes STFT parameters (1024 FFT, 256 hop, Hann window)
+and requests deterministic kernels. Remaining differences are due to floating
+point rounding in third‑party libraries.

--- a/mix/deterministic.py
+++ b/mix/deterministic.py
@@ -1,0 +1,52 @@
+"""Utilities for deterministic and reproducible execution."""
+import os
+import random
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - numpy optional
+    np = None
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch optional
+    torch = None
+
+# Default STFT parameters to keep CPU/GPU behaviour aligned.
+DEFAULT_FFT_SIZE = 1024
+DEFAULT_HOP_LENGTH = 256
+DEFAULT_WINDOW = "hann"
+
+
+def enable_determinism(seed: int = 0) -> None:
+    """Configure global libraries for deterministic behaviour.
+
+    This function seeds Python, NumPy and PyTorch random number generators and
+    toggles flags so that CUDA/cuDNN/BLAS produce repeatable results. It also
+    sets environment variables known to impact determinism.
+    """
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    if np is not None:
+        np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True
+        os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+        torch.backends.cuda.matmul.allow_tf32 = False
+
+
+def stft(signal, n_fft: int = DEFAULT_FFT_SIZE, hop_length: int = DEFAULT_HOP_LENGTH):
+    """Run a deterministic STFT using PyTorch.
+
+    Parameters mirror :func:`torch.stft` but use a fixed Hann window and do not
+    centre the signal, ensuring CPU/GPU parity.
+    """
+    if torch is None:
+        raise RuntimeError("PyTorch is required for STFT")
+    window = torch.hann_window(n_fft, device=signal.device)
+    return torch.stft(signal, n_fft=n_fft, hop_length=hop_length, window=window,
+                      center=False, return_complex=True)

--- a/scripts/mix_cli.py
+++ b/scripts/mix_cli.py
@@ -15,13 +15,24 @@ except Exception:  # pragma: no cover
     torch = None
 
 from mix import process
+try:
+    from mix.deterministic import enable_determinism
+except Exception:  # pragma: no cover
+    enable_determinism = None
 
 def main():
     parser = argparse.ArgumentParser(description="Mix stems into a single track")
     parser.add_argument("input", help="input directory containing stems")
     parser.add_argument("output", help="output directory")
     parser.add_argument("--reference", help="optional reference track")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="set random seed and enable deterministic backends",
+    )
     args = parser.parse_args()
+    if args.seed is not None and enable_determinism is not None:
+        enable_determinism(args.seed)
     device = "cuda" if (torch and torch.cuda.is_available()) else "cpu"
     print(f"Using device: {device}")
     report = process(Path(args.input), Path(args.output), reference=args.reference)

--- a/tests/smoke/test_determinism.py
+++ b/tests/smoke/test_determinism.py
@@ -1,0 +1,49 @@
+import array
+import wave
+
+import pytest
+
+from mix import process
+from mix.deterministic import enable_determinism, stft
+
+from tests.smoke.test_mix import _make_stems
+
+torch = pytest.importorskip("torch")
+
+
+def _peak_db(tensor):
+    peak = torch.max(torch.abs(tensor))
+    if peak == 0:
+        return -float("inf")
+    return 20 * torch.log10(peak).item()
+
+
+def test_cpu_gpu_alignment(tmp_path):
+    enable_determinism(0)
+    inp = tmp_path / "input"
+    _make_stems(inp)
+    out = tmp_path / "out"
+    report = process(inp, out)
+    mix_path = out / "mix.wav"
+    with wave.open(str(mix_path), "rb") as wf:
+        frames = wf.readframes(wf.getnframes())
+    ints = array.array("h", frames)
+    data = torch.tensor([s / 32768.0 for s in ints], dtype=torch.float32)
+
+    cpu_lufs = 20 * torch.log10(torch.sqrt(torch.mean(data ** 2))).item()
+    assert abs(cpu_lufs - report["mix_lufs"]) < 1e-6
+
+    if not (torch and torch.cuda.is_available()):
+        pytest.skip("CUDA not available")
+
+    spec_cpu = stft(data)
+    spec_gpu = stft(data.to("cuda")).cpu()
+    max_diff = torch.max(torch.abs(spec_cpu - spec_gpu)).item()
+    assert max_diff < 1e-6
+
+    gpu_lufs = 20 * torch.log10(torch.sqrt(torch.mean((data.to("cuda") ** 2)))).item()
+    assert abs(cpu_lufs - gpu_lufs) < 0.1
+
+    peak_cpu = _peak_db(data)
+    peak_gpu = _peak_db(data.to("cuda"))
+    assert abs(peak_cpu - peak_gpu) < 0.2


### PR DESCRIPTION
## Summary
- provide `mix.deterministic` module to seed RNGs and request deterministic kernels
- add CLI `--seed` option to enable reproducible runs
- document deterministic usage in README
- test CPU/GPU alignment of STFT with LUFS and peak thresholds

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968636ce4c83308b34ad37d3f854f3