### PR TITLE
Add YAML-based configuration system

### DIFF
--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -1,0 +1,6 @@
+{
+  "tracks": ["vocals", "drums", "bass", "other"],
+  "track_lufs": -23.0,
+  "mix_lufs": -14.0,
+  "quality_profile": "cpu_ultra"
+}

--- a/configs/models.yaml
+++ b/configs/models.yaml
@@ -1,0 +1,1 @@
+{"cpu_ultra": "standard_mixer", "gpu_ultra": "high_quality_mixer"}

--- a/configs/quality_profiles.yaml
+++ b/configs/quality_profiles.yaml
@@ -1,0 +1,4 @@
+{
+  "cpu_ultra": {"track_lufs": -23.0, "mix_lufs": -14.0},
+  "gpu_ultra": {"track_lufs": -20.0, "mix_lufs": -12.0}
+}

--- a/mix/config.py
+++ b/mix/config.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import os
+import json
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CONFIG_DIR = BASE_DIR / "configs"
+
+
+def get_config(profile: str | None = None) -> dict:
+    """Load configuration with priority: ENV > YAML defaults."""
+    with open(CONFIG_DIR / "defaults.yaml", "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    # Determine profile
+    profile = profile or os.getenv("MIX_PROFILE") or config.get("quality_profile")
+    if profile:
+        qp_path = CONFIG_DIR / "quality_profiles.yaml"
+        if qp_path.exists():
+            with open(qp_path, "r", encoding="utf-8") as f:
+                profiles = json.load(f)
+            config.update(profiles.get(profile, {}))
+        config["quality_profile"] = profile
+
+    # Environment overrides
+    if (env_tracks := os.getenv("MIX_TRACKS")):
+        config["tracks"] = [x.strip() for x in env_tracks.split(",") if x.strip()]
+    if (env_track := os.getenv("MIX_TRACK_LUFS")) is not None:
+        config["track_lufs"] = float(env_track)
+    if (env_mix := os.getenv("MIX_MIX_LUFS")) is not None:
+        config["mix_lufs"] = float(env_mix)
+
+    return config


### PR DESCRIPTION
## Summary
- introduce JSON/YAML config files for defaults, quality profiles, and models
- load configuration with CLI > ENV > file priority
- expose selected config in mix reports and allow profile switching

## Testing
- `PYTHONPATH=. pytest`
- `python - <<'PY'
from pathlib import Path
import os, math, wave, array
from mix import process

def write_tone(path, freq, duration=5, sr=44100):
    t = [math.sin(2*math.pi*freq*i/sr) for i in range(int(duration*sr))]
    ints = array.array('h', [int(max(-1.0,min(1.0,x))*32767) for x in t])
    path.parent.mkdir(parents=True, exist_ok=True)
    with wave.open(str(path),'wb') as wf:
        wf.setnchannels(1)
        wf.setsampwidth(2)
        wf.setframerate(sr)
        wf.writeframes(ints.tobytes())

def make_stems(directory):
    freqs = {"vocals":440, "drums":220, "bass":110, "other":330}
    for name,freq in freqs.items():
        write_tone(directory / f"{name}.wav", freq)

tmp = Path('tmp_profile')
inp = tmp / 'inp'
out = tmp / 'out'
make_stems(inp)
os.environ['MIX_PROFILE']='gpu_ultra'
report = process(inp, out)
print('profile mix lufs:', report['mix_lufs'])
print('profile used:', report['config']['quality_profile'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68968640c20c8330ad52861d034bd6a9