### PR TITLE
Add RVC model management with discovery and selector

### DIFF
--- a/mix/model_manager.py
+++ b/mix/model_manager.py
@@ -1,0 +1,46 @@
+import os
+import glob
+import logging
+
+DEFAULT_MODEL_PATH = "/content/drive/MyDrive/models/RVC/G_8200.pth"
+DISCOVERY_PATTERN = "/models/RVC/*.pth"
+ENV_VAR = "RVC_MODEL"
+
+
+def discover_models(pattern: str = DISCOVERY_PATTERN):
+    """Return a sorted list of available model files."""
+    return sorted(glob.glob(pattern))
+
+
+def get_model_path(cli_path: str = None, *, env_var: str = ENV_VAR,
+                   default: str = DEFAULT_MODEL_PATH,
+                   pattern: str = DISCOVERY_PATTERN,
+                   use_ui: bool = False):
+    """Determine which model path to use.
+
+    Priority: CLI argument > environment variable > default path. If the
+    resulting path does not exist, fall back to discovered models. When
+    ``use_ui`` is True and multiple models are available, the user is asked to
+    choose one interactively.
+    """
+    candidates = discover_models(pattern)
+    path = cli_path or os.getenv(env_var) or default
+    if not os.path.isfile(path):
+        if not candidates:
+            raise FileNotFoundError(
+                f"Model path '{path}' not found and no models available in '{pattern}'"
+            )
+        if use_ui and len(candidates) > 1:
+            print("Available models:")
+            for idx, model in enumerate(candidates, 1):
+                print(f"{idx}: {model}")
+            choice = input("Select model number: ")
+            try:
+                idx = int(choice) - 1
+                path = candidates[idx]
+            except (ValueError, IndexError):
+                raise FileNotFoundError(f"Invalid selection '{choice}'")
+        else:
+            path = candidates[0]
+    logging.info("Using model: %s", path)
+    return path

--- a/scripts/model_cli.py
+++ b/scripts/model_cli.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Command line tool for selecting RVC models."""
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from mix.model_manager import get_model_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Select RVC model")
+    parser.add_argument("--model", help="path to model file (.pth)")
+    parser.add_argument("--ui", action="store_true",
+                        help="interactive selection when needed")
+    args = parser.parse_args()
+    path = get_model_path(cli_path=args.model, use_ui=args.ui)
+    print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,0 +1,64 @@
+import os
+import logging
+import pytest
+
+from mix.model_manager import get_model_path
+
+
+def _write(path):
+    path.write_text("x")
+    return str(path)
+
+
+def test_default_used(monkeypatch, tmp_path):
+    default = _write(tmp_path / "G_8200.pth")
+    monkeypatch.delenv("RVC_MODEL", raising=False)
+    path = get_model_path(default=default, pattern=str(tmp_path / "*.pth"))
+    assert path == default
+
+
+def test_env_overrides_default(monkeypatch, tmp_path):
+    default = _write(tmp_path / "G_8200.pth")
+    env_model = _write(tmp_path / "env.pth")
+    monkeypatch.setenv("RVC_MODEL", env_model)
+    path = get_model_path(default=default, pattern=str(tmp_path / "*.pth"))
+    assert path == env_model
+
+
+def test_cli_overrides_env(monkeypatch, tmp_path, caplog):
+    default = _write(tmp_path / "G_8200.pth")
+    env_model = _write(tmp_path / "env.pth")
+    cli_model = _write(tmp_path / "cli.pth")
+    monkeypatch.setenv("RVC_MODEL", env_model)
+    caplog.set_level(logging.INFO)
+    path = get_model_path(cli_path=cli_model, default=default,
+                          pattern=str(tmp_path / "*.pth"))
+    assert path == cli_model
+    assert f"Using model: {cli_model}" in caplog.text
+
+
+def test_fallback_to_discovery(monkeypatch, tmp_path):
+    model_a = _write(tmp_path / "a.pth")
+    model_b = _write(tmp_path / "b.pth")
+    missing = str(tmp_path / "missing.pth")
+    monkeypatch.delenv("RVC_MODEL", raising=False)
+    path = get_model_path(default=missing, pattern=str(tmp_path / "*.pth"))
+    assert path == model_a
+
+
+def test_ui_selection(monkeypatch, tmp_path):
+    model_a = _write(tmp_path / "a.pth")
+    model_b = _write(tmp_path / "b.pth")
+    missing = str(tmp_path / "missing.pth")
+    monkeypatch.delenv("RVC_MODEL", raising=False)
+    monkeypatch.setattr("builtins.input", lambda _: "2")
+    path = get_model_path(default=missing, pattern=str(tmp_path / "*.pth"),
+                          use_ui=True)
+    assert path == model_b
+
+
+def test_no_model_raises(monkeypatch, tmp_path):
+    missing = str(tmp_path / "missing.pth")
+    monkeypatch.delenv("RVC_MODEL", raising=False)
+    with pytest.raises(FileNotFoundError):
+        get_model_path(default=missing, pattern=str(tmp_path / "*.pth"))


### PR DESCRIPTION
## Summary
- add `model_manager` module for handling RVC models with default path, auto-discovery and interactive selection
- provide `model_cli.py` for selecting models via CLI or environment variable
- include unit tests for model selection priority and fallbacks

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689686501b8c83309bb49d021173384a