### PR TITLE
feat: add UI notebook and CLI options

### DIFF
--- a/Colab_Bootstrap.ipynb
+++ b/Colab_Bootstrap.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, subprocess, sys\n",
+    "gpu = subprocess.run('nvidia-smi', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0\n",
+    "req = 'requirements-colab-gpu.txt' if gpu else 'requirements-colab-cpu.txt'\n",
+    "subprocess.run(['apt-get','-y','update'], check=True)\n",
+    "subprocess.run(['apt-get','-y','install','ffmpeg'], check=True)\n",
+    "subprocess.run([sys.executable,'-m','pip','install','-r',req], check=True)\n",
+    "if gpu:\n",
+    "    subprocess.run([sys.executable,'-m','pip','install','torch','torchaudio','torchvision','--index-url','https://download.pytorch.org/whl/cu121'], check=True)\n",
+    "else:\n",
+    "    subprocess.run([sys.executable,'-m','pip','install','torch','torchaudio','torchvision','--index-url','https://download.pytorch.org/whl/cpu'], check=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys, subprocess, math, wave, array\n",
+    "from pathlib import Path\n",
+    "from ipywidgets import Dropdown, FloatSlider, Text, Button, VBox, Output\n",
+    "\n",
+    "def _write_tone(path, freq, duration=5, sr=44100):\n",
+    "    t=[math.sin(2*math.pi*freq*i/sr) for i in range(int(duration*sr))]\n",
+    "    ints=array.array('h',[int(max(-1.0,min(1.0,x))*32767) for x in t])\n",
+    "    path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    with wave.open(str(path),'wb') as wf:\n",
+    "        wf.setnchannels(1); wf.setsampwidth(2); wf.setframerate(sr); wf.writeframes(ints.tobytes())\n",
+    "\n",
+    "def make_demo(directory):\n",
+    "    freqs={'vocals':440,'drums':220,'bass':110,'other':330}\n",
+    "    for name,f in freqs.items():\n",
+    "        _write_tone(directory/f'{name}.wav', f)\n",
+    "\n",
+    "inp_widget=Text(value='demo_stems', description='Input')\n",
+    "out_widget=Text(value='demo_output', description='Output')\n",
+    "model_widget=Dropdown(options=['basic','advanced'], value='basic', description='Model')\n",
+    "quality_widget=Dropdown(options=['low','medium','high'], value='medium', description='Quality')\n",
+    "lufs_widget=FloatSlider(value=-14.0, min=-30.0, max=0.0, step=1.0, description='Mix LUFS')\n",
+    "run_btn=Button(description='Run')\n",
+    "preview=Output()\n",
+    "\n",
+    "def run(_):\n",
+    "    preview.clear_output()\n",
+    "    inp=Path(inp_widget.value)\n",
+    "    out=Path(out_widget.value)\n",
+    "    if not inp.exists():\n",
+    "        make_demo(inp)\n",
+    "    cmd=[sys.executable, 'scripts/mix_cli.py', str(inp), str(out),\n",
+    "         '--model', model_widget.value,\n",
+    "         '--quality', quality_widget.value,\n",
+    "         '--mix-lufs', str(lufs_widget.value)]\n",
+    "    with preview:\n",
+    "        print('Command:', ' '.join(cmd))\n",
+    "    subprocess.run(cmd, check=True)\n",
+    "\n",
+    "run_btn.on_click(run)\n",
+    "VBox([inp_widget, out_widget, model_widget, quality_widget, lufs_widget, run_btn, preview])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/mix_cli.py
+++ b/scripts/mix_cli.py
@@ -21,10 +21,41 @@ def main():
     parser.add_argument("input", help="input directory containing stems")
     parser.add_argument("output", help="output directory")
     parser.add_argument("--reference", help="optional reference track")
+    parser.add_argument(
+        "--model",
+        choices=["basic", "advanced"],
+        default="basic",
+        help="mixing model to use",
+    )
+    parser.add_argument(
+        "--quality",
+        choices=["low", "medium", "high"],
+        default="medium",
+        help="quality grade",
+    )
+    parser.add_argument(
+        "--track-lufs",
+        type=float,
+        default=-23.0,
+        help="target loudness for individual tracks",
+    )
+    parser.add_argument(
+        "--mix-lufs",
+        type=float,
+        default=-14.0,
+        help="target loudness for final mix",
+    )
     args = parser.parse_args()
     device = "cuda" if (torch and torch.cuda.is_available()) else "cpu"
     print(f"Using device: {device}")
-    report = process(Path(args.input), Path(args.output), reference=args.reference)
+    print(f"Model: {args.model}, Quality: {args.quality}")
+    report = process(
+        Path(args.input),
+        Path(args.output),
+        reference=args.reference,
+        track_lufs=args.track_lufs,
+        mix_lufs=args.mix_lufs,
+    )
     print(json.dumps(report, indent=2))
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Colab_Bootstrap notebook with interactive widgets to assemble mix CLI commands
- extend mix_cli with model, quality, and loudness options

## Testing
- `PYTHONPATH=. pytest tests/smoke/test_mix.py`


------
https://chatgpt.com/codex/tasks/task_e_689686599878833097c4d34efebfba40