### PR TITLE
feat: add io path strategy with drive fallback

### DIFF
--- a/docs/io_strategy.md
+++ b/docs/io_strategy.md
@@ -1,0 +1,40 @@
+# I/O Path Strategy
+
+This project supports two storage channels: the local `/content` filesystem and Google Drive. The utilities in `scripts/io_utils.py` provide unified path handling to avoid permission and path issues.
+
+## Default Directories
+
+- **Local**: `/content/input` and `/content/output`
+- **Drive**: `/content/drive/MyDrive/input` and `/content/drive/MyDrive/output`
+
+`get_default_io()` attempts to mount Google Drive and falls back to the local filesystem if the mount fails.
+
+## Mounting with Fallback
+
+The code tries to `google.colab.drive.mount("/content/drive")`. If the attempt raises an exception or the path does not exist, local paths are used.
+
+## Space & Permission Checks
+
+`resolve_output_path()` ensures the target directory exists, is readable and writable, and has at least 100 MB free space. This helps stability with large files.
+
+## Usage Examples
+
+```python
+from scripts.io_utils import get_default_io, resolve_input_path
+
+# Use defaults (Drive when available, otherwise local)
+inp, out = get_default_io()
+
+# Explicit paths, converted to absolute paths with checks
+inp = resolve_input_path("~/data/song1")
+out = resolve_output_path("~/results/song1")
+```
+
+When running inside Colab:
+
+```bash
+!python scripts/mix_cli.py               # uses defaults
+!python scripts/mix_cli.py /path/in /path/out
+```
+
+On a workstation the same code works with the local filesystem only.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Helper package for command-line scripts.

--- a/scripts/batch_mix.py
+++ b/scripts/batch_mix.py
@@ -4,6 +4,8 @@ import argparse
 from pathlib import Path
 import sys
 
+from io_utils import get_default_io, resolve_input_path, resolve_output_path
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -13,12 +15,19 @@ from mix import process
 
 def main():
     parser = argparse.ArgumentParser(description="Batch mix songs")
-    parser.add_argument("input_root", help="root directory containing song folders")
-    parser.add_argument("output_root", help="where to place mixed outputs")
+    parser.add_argument("input_root", nargs="?", help="root directory containing song folders")
+    parser.add_argument("output_root", nargs="?", help="where to place mixed outputs")
     args = parser.parse_args()
-    for song_dir in Path(args.input_root).iterdir():
+
+    if args.input_root and args.output_root:
+        inp_root = resolve_input_path(args.input_root)
+        out_root = resolve_output_path(args.output_root)
+    else:
+        inp_root, out_root = get_default_io()
+
+    for song_dir in Path(inp_root).iterdir():
         if song_dir.is_dir():
-            out_dir = Path(args.output_root) / song_dir.name
+            out_dir = Path(out_root) / song_dir.name
             print(f"Processing {song_dir} -> {out_dir}")
             process(song_dir, out_dir)
 

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -1,0 +1,58 @@
+"""Input/output directory helpers with optional Google Drive support."""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+DEFAULT_LOCAL_ROOT = Path("/content")
+DEFAULT_DRIVE_ROOT = Path("/content/drive/MyDrive")
+REQUIRED_FREE_BYTES = 100 * 1024 * 1024  # 100 MB
+
+
+def _has_rw(path: Path) -> bool:
+    return os.access(path, os.R_OK | os.W_OK)
+
+
+def resolve_input_path(path: str | Path) -> Path:
+    """Resolve an input directory path and ensure read/write access."""
+    p = Path(path).expanduser().resolve()
+    if not p.exists():
+        raise FileNotFoundError(f"{p} not found")
+    if not _has_rw(p):
+        raise PermissionError(f"No read/write access to {p}")
+    return p
+
+
+def resolve_output_path(path: str | Path, required_bytes: int = REQUIRED_FREE_BYTES) -> Path:
+    """Resolve an output directory path, ensuring it exists and has space."""
+    p = Path(path).expanduser().resolve()
+    p.mkdir(parents=True, exist_ok=True)
+    if not _has_rw(p):
+        raise PermissionError(f"No read/write access to {p}")
+    _total, _used, free = shutil.disk_usage(p)
+    if free < required_bytes:
+        raise OSError(f"Not enough free space in {p}: {free} bytes available")
+    return p
+
+
+def _mount_or_local() -> Path:
+    """Try to mount Google Drive; fall back to local /content."""
+    try:
+        from google.colab import drive  # type: ignore
+
+        if not DEFAULT_DRIVE_ROOT.exists():
+            drive.mount(str(DEFAULT_DRIVE_ROOT.parent))
+        if DEFAULT_DRIVE_ROOT.exists():
+            return DEFAULT_DRIVE_ROOT
+    except Exception:
+        pass
+    return DEFAULT_LOCAL_ROOT
+
+
+def get_default_io(required_bytes: int = REQUIRED_FREE_BYTES) -> tuple[Path, Path]:
+    """Return default input/output directories with checks."""
+    base = _mount_or_local()
+    input_dir = resolve_output_path(base / "input", required_bytes)
+    output_dir = resolve_output_path(base / "output", required_bytes)
+    return input_dir, output_dir

--- a/scripts/mix_cli.py
+++ b/scripts/mix_cli.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 import sys
 
+from io_utils import get_default_io, resolve_input_path, resolve_output_path
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -18,13 +20,21 @@ from mix import process
 
 def main():
     parser = argparse.ArgumentParser(description="Mix stems into a single track")
-    parser.add_argument("input", help="input directory containing stems")
-    parser.add_argument("output", help="output directory")
+    parser.add_argument("input", nargs="?", help="input directory containing stems")
+    parser.add_argument("output", nargs="?", help="output directory")
     parser.add_argument("--reference", help="optional reference track")
     args = parser.parse_args()
+
     device = "cuda" if (torch and torch.cuda.is_available()) else "cpu"
     print(f"Using device: {device}")
-    report = process(Path(args.input), Path(args.output), reference=args.reference)
+
+    if args.input and args.output:
+        inp = resolve_input_path(args.input)
+        out = resolve_output_path(args.output)
+    else:
+        inp, out = get_default_io()
+
+    report = process(inp, out, reference=args.reference)
     print(json.dumps(report, indent=2))
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/smoke/test_io_utils.py
+++ b/tests/smoke/test_io_utils.py
@@ -1,0 +1,7 @@
+from scripts.io_utils import get_default_io, DEFAULT_LOCAL_ROOT
+
+
+def test_get_default_io_local_fallback():
+    inp, out = get_default_io()
+    assert str(inp).startswith(str(DEFAULT_LOCAL_ROOT))
+    assert inp.exists() and out.exists()


### PR DESCRIPTION
## Summary
- add IO path strategy doc describing default local/Drive directories, Drive mount fallback, and permission/space checks
- introduce `io_utils` with helpers for resolving paths and selecting default directories
- update CLI scripts to use new utilities and support optional arguments
- add smoke test for IO defaults and test configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968662ae34833083340da119eb084a