### PR TITLE
feat: add high quality resampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/FusinKoo/Jules-Test-02/blob/main/notebooks/demo.ipynb)
 
-This repository provides a minimal library, command line tools and a demo notebook for automatic music mixing.
+This repository provides a minimal library, command line tools and a demo notebook for automatic music mixing.  Audio is processed
+internally at **48 kHz / 32‑bit float** and any required sample rate conversions use `soxr` with the "best" quality setting.  The
+final mix is exported as **48 kHz / 24‑bit PCM** and the report includes a list of sample rate conversion points.
 
 ## Structure
 

--- a/mix/__init__.py
+++ b/mix/__init__.py
@@ -1,4 +1,13 @@
-"""Minimal audio mixing library using only the Python standard library."""
+"""Minimal audio mixing library with high quality resampling.
+
+Audio is mixed in a fixed internal processing format of 48 kHz / float. If
+input stems use a different sample rate they are resampled on load using
+`soxr` with the "best" quality setting when available. When `soxr` is not
+installed a simple linear interpolation resampler is used as a fallback.
+The final mix is written as 48 kHz / 24-bit PCM and the processing report
+includes a list of sample rate conversion points.
+"""
+
 from pathlib import Path
 import json
 import wave
@@ -6,6 +15,30 @@ import array
 import math
 
 TRACKS = ["vocals", "drums", "bass", "other"]
+INTERNAL_SR = 48_000
+
+try:  # optional dependency
+    import soxr  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully
+    soxr = None
+
+
+def _resample(data, src_sr, dst_sr):
+    if src_sr == dst_sr:
+        return data
+    if soxr is not None:
+        return list(soxr.resample(data, src_sr, dst_sr, quality="best"))
+    # fallback: linear interpolation
+    ratio = dst_sr / src_sr
+    n = int(round(len(data) * ratio))
+    result = [0.0] * n
+    for i in range(n):
+        x = i / ratio
+        i0 = int(math.floor(x))
+        i1 = min(i0 + 1, len(data) - 1)
+        frac = x - i0
+        result[i] = data[i0] * (1 - frac) + data[i1] * frac
+    return result
 
 
 def _load(path):
@@ -13,19 +46,29 @@ def _load(path):
         sr = wf.getframerate()
         frames = wf.readframes(wf.getnframes())
         data = array.array("h", frames)
-    # convert to float in [-1, 1]
     data = [s / 32768.0 for s in data]
-    return data, sr
+    orig_sr = sr
+    if sr != INTERNAL_SR:
+        data = _resample(data, sr, INTERNAL_SR)
+    return data, orig_sr
 
 
-def _save(path, data, sr):
+def _float_to_24bit_bytes(data):
+    max_int = 2 ** 23 - 1
+    for x in data:
+        v = max(-1.0, min(1.0, x))
+        iv = int(v * max_int)
+        yield int(iv).to_bytes(4, "little", signed=True)[:3]
+
+
+def _save(path, data):
     path.parent.mkdir(parents=True, exist_ok=True)
-    ints = array.array("h", [max(-32768, min(32767, int(x * 32767))) for x in data])
+    frames = b"".join(_float_to_24bit_bytes(data))
     with wave.open(str(path), "wb") as wf:
         wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(sr)
-        wf.writeframes(ints.tobytes())
+        wf.setsampwidth(3)
+        wf.setframerate(INTERNAL_SR)
+        wf.writeframes(frames)
 
 
 def _rms_db(data):
@@ -52,29 +95,41 @@ def process(input_dir, output_dir, reference=None, track_lufs=-23.0, mix_lufs=-1
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)
     tracks = {}
-    report = {"tracks": {}}
-    sr = None
+    report = {"tracks": {}, "sample_rate_conversions": []}
+
     for name in TRACKS:
         stem_path = input_dir / f"{name}.wav"
         if stem_path.exists():
-            data, sr = _load(stem_path)
+            data, orig_sr = _load(stem_path)
+            if orig_sr != INTERNAL_SR:
+                report["sample_rate_conversions"].append(
+                    {"stage": f"input_{name}", "from": orig_sr, "to": INTERNAL_SR}
+                )
             norm, loudness, gain = _align_loudness(data, track_lufs)
             tracks[name] = norm
             report["tracks"][name] = {"input_db": loudness, "gain_db": gain}
+
     if not tracks:
         raise FileNotFoundError("No stem files found in input directory")
+
     length = min(len(t) for t in tracks.values())
     mix = [0.0] * length
     for t in tracks.values():
         for i in range(length):
             mix[i] += t[i]
+
     mix, _before_loudness, gain = _align_loudness(mix, mix_lufs)
-    _save(output_dir / "mix.wav", mix, sr)
+    _save(output_dir / "mix.wav", mix)
+
     final_loudness = _rms_db(mix)
     with open(output_dir / "mix_lufs.txt", "w") as f:
         f.write(f"{final_loudness:.2f}")
+
     report["mix_lufs"] = final_loudness
     report["mix_gain_db"] = gain
+
     with open(output_dir / "report.json", "w") as f:
         json.dump(report, f, indent=2)
+
     return report
+

--- a/requirements-colab-cpu.txt
+++ b/requirements-colab-cpu.txt
@@ -4,3 +4,4 @@ librosa==0.10.2.post1
 soundfile>=0.12
 audioread>=3.0
 tqdm
+soxr>=0.3.5

--- a/requirements-colab-gpu.txt
+++ b/requirements-colab-gpu.txt
@@ -4,3 +4,4 @@ librosa==0.10.2.post1
 soundfile>=0.12
 audioread>=3.0
 tqdm
+soxr>=0.3.5

--- a/tests/smoke/test_mix.py
+++ b/tests/smoke/test_mix.py
@@ -2,7 +2,13 @@ from pathlib import Path
 import math
 import wave
 import array
-from mix import process
+
+try:  # optional dependency
+    import soundfile as sf  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully
+    sf = None
+
+from mix import process, INTERNAL_SR
 
 
 def _write_tone(path, freq, duration=5, sr=44100):
@@ -22,12 +28,23 @@ def _write_tone(path, freq, duration=5, sr=44100):
         wf.writeframes(ints.tobytes())
 
 def _rms_db(path):
-    with wave.open(str(path), "rb") as wf:
-        frames = wf.readframes(wf.getnframes())
-    data = array.array("h", frames)
-    floats = [s/32768.0 for s in data]
-    rms = math.sqrt(sum(x*x for x in floats)/len(floats))
-    return 20*math.log10(rms)
+    if sf is not None:
+        data, _sr = sf.read(str(path), dtype="float32")
+        rms = math.sqrt(sum(x * x for x in data) / len(data))
+    else:
+        with wave.open(str(path), "rb") as wf:
+            frames = wf.readframes(wf.getnframes())
+        data = []
+        for i in range(0, len(frames), 3):
+            chunk = frames[i : i + 3]
+            if chunk[2] & 0x80:
+                chunk += b"\xff"
+            else:
+                chunk += b"\x00"
+            sample = int.from_bytes(chunk, "little", signed=True)
+            data.append(sample / 8388608.0)
+        rms = math.sqrt(sum(x * x for x in data) / len(data))
+    return 20 * math.log10(rms)
 
 
 def _make_stems(directory):
@@ -42,6 +59,14 @@ def test_mix(tmp_path):
     report = process(inp, out)
     mix_file = out / "mix.wav"
     assert mix_file.exists()
+    if sf is not None:
+        info = sf.info(mix_file)
+        assert info.samplerate == INTERNAL_SR
+        assert info.subtype == "PCM_24"
+    else:
+        with wave.open(str(mix_file), "rb") as wf:
+            assert wf.getframerate() == INTERNAL_SR
+            assert wf.getsampwidth() == 3
     loudness = _rms_db(mix_file)
     assert abs(loudness - (-14.0)) < 1.0
     assert "mix_lufs" in report


### PR DESCRIPTION
## Summary
- mix stems using a fixed 48 kHz internal format
- resample with soxr when available and export 24-bit PCM
- record sample-rate conversion points and validate 48 kHz output

## Testing
- `PYTHONPATH=. pytest tests/smoke/test_mix.py`


------
https://chatgpt.com/codex/tasks/task_e_6896866a4ae48330b077d9110d63b35d