### PR TITLE
Implement configurable loudness mastering with true-peak limiting

### DIFF
--- a/mix/__init__.py
+++ b/mix/__init__.py
@@ -48,6 +48,67 @@ def _align_loudness(data, target_db):
     return _apply_gain(data, gain), loudness, gain
 
 
+def _true_peak_db(data, oversample=4):
+    """Approximate true-peak level in dBFS with simple oversampling."""
+    if not data:
+        return -float("inf")
+    peak = 0.0
+    prev = data[0]
+    for cur in data[1:]:
+        for i in range(oversample):
+            t = i / oversample
+            val = prev + (cur - prev) * t
+            if abs(val) > peak:
+                peak = abs(val)
+        prev = cur
+    if peak == 0.0:
+        return -float("inf")
+    return 20 * math.log10(peak)
+
+
+def _soft_limit(data, peak_db=-1.0):
+    """Softly limit samples above the given peak (in dBFS)."""
+    threshold = math.pow(10.0, peak_db / 20.0)
+    limited = []
+    for x in data:
+        if abs(x) <= threshold:
+            limited.append(x)
+        else:
+            limited.append(math.tanh(x / threshold) * threshold)
+    return limited
+
+
+def master(data, target_lufs=-14.0, target_tp=-1.0):
+    """Master a mono track to the given loudness and true-peak targets.
+
+    Returns the processed audio and a report of loudness/peak measurements.
+    """
+    processed, in_lufs, gain = _align_loudness(data, target_lufs)
+    pre_lufs = _rms_db(processed)
+    pre_tp = _true_peak_db(processed)
+    limited = _soft_limit(processed, peak_db=target_tp)
+    report = {
+        "input_lufs": in_lufs,
+        "input_tp": _true_peak_db(data),
+        "gain_db": gain,
+        "pre_limit_lufs": pre_lufs,
+        "pre_limit_tp": pre_tp,
+        "output_lufs": _rms_db(limited),
+        "output_tp": _true_peak_db(limited),
+    }
+    return limited, report
+
+
+def master_file(input_path, output_path, target_lufs=-14.0, target_tp=-1.0):
+    """File based wrapper around :func:`master`."""
+    data, sr = _load(input_path)
+    processed, report = master(data, target_lufs=target_lufs, target_tp=target_tp)
+    _save(output_path, processed, sr)
+    with open(Path(output_path).with_suffix(".json"), "w") as f:
+        json.dump(report, f, indent=2)
+    return report
+
+
 def process(input_dir, output_dir, reference=None, track_lufs=-23.0, mix_lufs=-14.0):
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Ensure project root on path for imports
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))

--- a/tests/smoke/test_master.py
+++ b/tests/smoke/test_master.py
@@ -1,0 +1,20 @@
+import math
+from mix import master
+
+
+def _tone(freq=440.0, amp=0.2, duration=1, sr=44100):
+    return [amp * math.sin(2 * math.pi * freq * i / sr) for i in range(int(duration * sr))]
+
+
+def test_master_loudness():
+    base = _tone()
+    sr = 44100
+    # create 10 inputs with varying impulse peaks
+    peaks = [0.2 * i for i in range(10)]  # 0.0 .. 1.8
+    for i, peak in enumerate(peaks):
+        data = base.copy()
+        idx = min(i * 1000, len(data) - 1)
+        data[idx] += peak
+        processed, report = master(data)
+        assert abs(report["output_lufs"] - (-14.0)) < 1.0
+        assert report["output_tp"] <= -0.9  # allow small tolerance


### PR DESCRIPTION
## Summary
- add true-peak estimation and soft limiter
- provide `master`/`master_file` utilities to hit -14 LUFS and -1 dBTP by default
- test mastering across 10 generated inputs and ensure imports work via conftest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689686a0fa748330bf61c10ef8f13ce3