### PR TITLE
Add environment health checks and tests

### DIFF
--- a/mix/health.py
+++ b/mix/health.py
@@ -1,0 +1,113 @@
+"""Environment health checks for audio mixing.
+
+Provides utilities to verify required runtime dependencies such as GPU
+memory, disk space, ffmpeg executable and audio sample rates.  Each check
+returns an error string explaining the problem and a possible fix.  A
+`run_preflight_checks` helper aggregates the individual checks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import wave
+
+try:  # pragma: no cover - optional dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover
+    torch = None  # type: ignore
+
+
+def check_gpu(min_free_mb: int = 1024) -> str | None:
+    """Validate that a CUDA device has at least ``min_free_mb`` free memory."""
+    if not torch or not hasattr(torch, "cuda") or not torch.cuda.is_available():
+        return (
+            "CUDA GPU not available. Install a CUDA capable GPU or run on CPU."
+        )
+    try:
+        free_bytes, _total = torch.cuda.mem_get_info()  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - API may not exist
+        return "Unable to determine GPU memory. Ensure recent PyTorch installation."
+    free_mb = free_bytes / 1024**2
+    if free_mb < min_free_mb:
+        return (
+            f"Insufficient GPU memory: {free_mb:.0f}MB available, "
+            f"{min_free_mb}MB required. Close other applications or reduce batch size."
+        )
+    return None
+
+
+def check_disk(path: str | Path, min_free_mb: int = 1024) -> str | None:
+    """Ensure the filesystem containing ``path`` has enough free space."""
+    usage = shutil.disk_usage(Path(path))
+    free_mb = usage.free / 1024**2
+    if free_mb < min_free_mb:
+        return (
+            f"Insufficient disk space at {path}: {free_mb:.0f}MB available, "
+            f"{min_free_mb}MB required. Free up space or choose another location."
+        )
+    return None
+
+
+def check_ffmpeg() -> str | None:
+    """Verify that the ffmpeg executable is available on PATH."""
+    if not shutil.which("ffmpeg"):
+        return "ffmpeg executable not found. Install ffmpeg and ensure it is on PATH."
+    return None
+
+
+def check_sample_rate(input_dir: str | Path | None, expected_sr: int = 44100) -> str | None:
+    """Confirm that all ``.wav`` files in ``input_dir`` have the expected sample rate."""
+    if not input_dir:
+        return None
+    input_dir = Path(input_dir)
+    errors = []
+    for wav_path in input_dir.glob("*.wav"):
+        with wave.open(str(wav_path), "rb") as wf:
+            sr = wf.getframerate()
+        if sr != expected_sr:
+            errors.append(
+                f"{wav_path.name} has sample rate {sr}Hz, expected {expected_sr}Hz."
+            )
+    if errors:
+        return "; ".join(errors)
+    return None
+
+
+def check_model(model_path: str | Path | None) -> str | None:
+    """Check that the optional model file exists."""
+    if not model_path:
+        return None
+    model_path = Path(model_path)
+    if not model_path.exists():
+        return (
+            f"Model file not found: {model_path}. Download the model or provide the correct path."
+        )
+    return None
+
+
+def run_preflight_checks(
+    input_dir: str | Path | None = None,
+    output_dir: str | Path = ".",
+    model_path: str | Path | None = None,
+    expected_sr: int = 44100,
+    min_gpu_mem_mb: int = 1024,
+    min_disk_mb: int = 1024,
+) -> list[str]:
+    """Run all health checks and return a list of error messages."""
+    errors = []
+    gpu_err = check_gpu(min_gpu_mem_mb)
+    if gpu_err:
+        errors.append(gpu_err)
+    disk_err = check_disk(output_dir, min_disk_mb)
+    if disk_err:
+        errors.append(disk_err)
+    ffmpeg_err = check_ffmpeg()
+    if ffmpeg_err:
+        errors.append(ffmpeg_err)
+    sr_err = check_sample_rate(input_dir, expected_sr)
+    if sr_err:
+        errors.append(sr_err)
+    model_err = check_model(model_path)
+    if model_err:
+        errors.append(model_err)
+    return errors

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Command line interface to run environment health checks."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from mix.health import run_preflight_checks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run environment preflight checks")
+    parser.add_argument("--input", help="directory with input wav files for sample rate check")
+    parser.add_argument(
+        "--output",
+        default=".",
+        help="directory used for disk space check (defaults to current directory)",
+    )
+    parser.add_argument("--model", help="path to required model file", default=None)
+    parser.add_argument("--expected-sr", type=int, default=44100, help="expected sample rate")
+    parser.add_argument(
+        "--min-gpu-mem",
+        type=int,
+        default=1024,
+        help="minimum free GPU memory in MB",
+    )
+    parser.add_argument(
+        "--min-disk", type=int, default=1024, help="minimum free disk space in MB"
+    )
+    args = parser.parse_args()
+
+    errors = run_preflight_checks(
+        input_dir=args.input,
+        output_dir=args.output,
+        model_path=args.model,
+        expected_sr=args.expected_sr,
+        min_gpu_mem_mb=args.min_gpu_mem,
+        min_disk_mb=args.min_disk,
+    )
+    if errors:
+        print("Environment check failed:")
+        for err in errors:
+            print(f"- {err}")
+        sys.exit(1)
+    print("Environment check passed.")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,64 @@
+import wave
+from pathlib import Path
+
+import pytest
+
+from mix import health
+
+
+def _create_wav(path: Path, sr: int) -> None:
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        wf.writeframes(b"\x00\x00" * sr)
+
+
+def test_sample_rate_error(tmp_path):
+    _create_wav(tmp_path / "a.wav", 22050)
+    errors = health.run_preflight_checks(
+        input_dir=tmp_path, min_gpu_mem_mb=0, min_disk_mb=0
+    )
+    assert any("22050" in e for e in errors)
+
+
+def test_model_missing():
+    errors = health.run_preflight_checks(
+        model_path="missing.pth", min_gpu_mem_mb=0, min_disk_mb=0
+    )
+    assert any("missing.pth" in e for e in errors)
+
+
+def test_ffmpeg_missing(monkeypatch):
+    monkeypatch.setattr(health.shutil, "which", lambda name: None)
+    errors = health.run_preflight_checks(min_gpu_mem_mb=0, min_disk_mb=0)
+    assert any("ffmpeg" in e for e in errors)
+
+
+def test_disk_space(monkeypatch):
+    class FakeUsage:
+        total = 0
+        used = 0
+        free = 0
+
+    monkeypatch.setattr(health.shutil, "disk_usage", lambda path: FakeUsage)
+    errors = health.run_preflight_checks(min_gpu_mem_mb=0, min_disk_mb=1)
+    assert any("disk space" in e for e in errors)
+
+
+def test_gpu_memory(monkeypatch):
+    class FakeCuda:
+        @staticmethod
+        def is_available():
+            return True
+
+        @staticmethod
+        def mem_get_info():
+            return (0, 1 << 30)  # 0 bytes free, 1GB total
+
+    class FakeTorch:
+        cuda = FakeCuda()
+
+    monkeypatch.setattr(health, "torch", FakeTorch())
+    errors = health.run_preflight_checks(min_gpu_mem_mb=1, min_disk_mb=0)
+    assert any("GPU" in e for e in errors)


### PR DESCRIPTION
## Summary
- Add reusable health check utilities for GPU memory, disk space, ffmpeg availability, sample rates and model files
- Provide `health_check` CLI to run preflight checks with clear guidance
- Cover failure scenarios with unit tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689686d370708330a07ca922896bd3ae