### PR TITLE
Add batch executor with progress reporting and retries

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -1,0 +1,74 @@
+import sys
+import time
+from typing import Callable, Iterable, List, Optional
+
+class BatchExecutor:
+    """Execute a sequence of callables with progress and retry logic.
+
+    Parameters
+    ----------
+    tasks: Iterable[Callable]
+        Callables to execute. Each task is called with no arguments.
+    max_retries: int, optional
+        Number of times to retry a failed task. Defaults to 0 (no retries).
+    bar_width: int, optional
+        Width of the textual progress bar. Defaults to 20 characters.
+    out: file-like object, optional
+        Stream where progress is written. Defaults to ``sys.stdout``.
+    """
+    def __init__(self, tasks: Iterable[Callable], max_retries: int = 0,
+                 bar_width: int = 20, out: Optional[object] = None) -> None:
+        self.tasks: List[Callable] = list(tasks)
+        self.max_retries = max_retries
+        self.bar_width = bar_width
+        self.out = out or sys.stdout
+
+    # ------------------------------------------------------------------
+    def _progress(self, completed: int, total: int, start: float) -> None:
+        """Render progress bar with ETA."""
+        elapsed = time.time() - start
+        rate = elapsed / completed if completed else 0.0
+        remaining = total - completed
+        eta = remaining * rate
+        pct = completed / total if total else 0.0
+        filled = int(self.bar_width * pct)
+        bar = '[' + '=' * filled + ' ' * (self.bar_width - filled) + ']'
+        msg = f"\r{bar} {completed}/{total} ({pct*100:5.1f}%) ETA {eta:5.1f}s"
+        self.out.write(msg)
+        self.out.flush()
+
+    # ------------------------------------------------------------------
+    def run(self) -> dict:
+        """Run all tasks in order.
+
+        Returns a report dictionary containing counts and timings.
+        """
+        total = len(self.tasks)
+        stats = {
+            'total': total,
+            'succeeded': 0,
+            'failed': 0,
+            'retries': 0,
+        }
+        start = time.time()
+        for i, task in enumerate(self.tasks, 1):
+            attempt = 0
+            while True:
+                try:
+                    task()
+                    stats['succeeded'] += 1
+                    break
+                except Exception:
+                    if attempt < self.max_retries:
+                        stats['retries'] += 1
+                        attempt += 1
+                        continue
+                    else:
+                        stats['failed'] += 1
+                        break
+            self._progress(i, total, start)
+        self.out.write('\n')
+        stats['elapsed'] = time.time() - start
+        return stats
+
+__all__ = ["BatchExecutor"]

--- a/scripts/batch_mix.py
+++ b/scripts/batch_mix.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-"""Batch processing of multiple song folders."""
+"""Batch processing of multiple song folders with progress and retries."""
 import argparse
+from functools import partial
 from pathlib import Path
 import sys
 
@@ -9,18 +10,29 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from mix import process
+from batch import BatchExecutor
 
 
 def main():
     parser = argparse.ArgumentParser(description="Batch mix songs")
     parser.add_argument("input_root", help="root directory containing song folders")
     parser.add_argument("output_root", help="where to place mixed outputs")
+    parser.add_argument("--retries", type=int, default=0,
+                        help="number of times to retry failed mixes")
     args = parser.parse_args()
+    tasks = []
     for song_dir in Path(args.input_root).iterdir():
         if song_dir.is_dir():
             out_dir = Path(args.output_root) / song_dir.name
-            print(f"Processing {song_dir} -> {out_dir}")
-            process(song_dir, out_dir)
+            tasks.append(partial(process, song_dir, out_dir))
+    if not tasks:
+        print("No song folders found.")
+        return
+    executor = BatchExecutor(tasks, max_retries=args.retries)
+    report = executor.run()
+    print(f"Completed: {report['succeeded']} succeeded, {report['failed']} failed, "
+          f"retries: {report['retries']}, elapsed: {report['elapsed']:.1f}s")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/smoke/test_batch_executor.py
+++ b/tests/smoke/test_batch_executor.py
@@ -1,0 +1,27 @@
+from batch import BatchExecutor
+
+
+def test_batch_executor_retry(capsys):
+    calls = {'b': 0}
+
+    def task_ok():
+        pass
+
+    def task_retry():
+        calls['b'] += 1
+        if calls['b'] < 2:
+            raise RuntimeError('fail once')
+
+    def task_fail():
+        raise RuntimeError('always fail')
+
+    executor = BatchExecutor([task_ok, task_retry, task_fail], max_retries=1)
+    report = executor.run()
+    out = capsys.readouterr().out.replace('\r', '\n')
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert '3/3' in lines[-1]
+    assert 'ETA' in lines[-1]
+    assert report['total'] == 3
+    assert report['succeeded'] == 2
+    assert report['failed'] == 1
+    assert report['retries'] == 2


### PR DESCRIPTION
## Summary
- add generic BatchExecutor with progress bar, ETA and retry support
- extend batch_mix CLI to use BatchExecutor and allow retry configuration
- cover executor behavior with tests for progress output and retries

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689686ed8be08330ad686fd0b6c7dad7