### PR TITLE
feat: add RVC model discovery and selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ Arguments:
 - `--truepeak_margin` – true peak margin in dB.
 - `--dry_run` – run without producing output.
 
+## RVC model selection
+
+By default the toolkit expects an RVC model at
+`/content/drive/MyDrive/models/RVC/G_8200.pth`. All `.pth` files inside
+`/content/drive/MyDrive/models/RVC/` are scanned on startup and presented as
+candidates.
+
+Model priority is:
+
+1. `--rvc_model` command line argument
+2. `RVC_MODEL` environment variable
+3. Notebook drop‑down selection when multiple models are available
+
+If none of these resolve to an existing file the default path is used. When no
+model can be found an explicit error is raised with instructions to upload one
+to the directory above.
+
 ## Tests
 
 Run the smoke test that generates synthetic stems:

--- a/mix/model_manager.py
+++ b/mix/model_manager.py
@@ -1,15 +1,52 @@
 import os
 import glob
 import logging
+import threading
 
 DEFAULT_MODEL_PATH = "/content/drive/MyDrive/models/RVC/G_8200.pth"
-DISCOVERY_PATTERN = "/models/RVC/*.pth"
+DISCOVERY_PATTERN = "/content/drive/MyDrive/models/RVC/*.pth"
 ENV_VAR = "RVC_MODEL"
 
 
 def discover_models(pattern: str = DISCOVERY_PATTERN):
     """Return a sorted list of available model files."""
     return sorted(glob.glob(pattern))
+
+
+def _select_model(candidates):
+    """Interactively choose a model from the list.
+
+    Uses a notebook dropdown when ``ipywidgets`` is available, otherwise
+    falls back to simple CLI input.
+    """
+    try:
+        from IPython.display import display
+        import ipywidgets as widgets
+
+        event = threading.Event()
+        dropdown = widgets.Dropdown(
+            options=[(os.path.basename(p), p) for p in candidates],
+            description="Model:",
+        )
+        button = widgets.Button(description="Select")
+
+        def _on_click(_):
+            event.set()
+
+        button.on_click(_on_click)
+        display(dropdown, button)
+        event.wait()
+        return dropdown.value
+    except Exception:
+        print("Available models:")
+        for idx, model in enumerate(candidates, 1):
+            print(f"{idx}: {model}")
+        choice = input("Select model number: ")
+        try:
+            idx = int(choice) - 1
+            return candidates[idx]
+        except (ValueError, IndexError):
+            raise FileNotFoundError(f"Invalid selection '{choice}'")
 
 
 def get_model_path(cli_path: str = None, *, env_var: str = ENV_VAR,
@@ -28,18 +65,11 @@ def get_model_path(cli_path: str = None, *, env_var: str = ENV_VAR,
     if not os.path.isfile(path):
         if not candidates:
             raise FileNotFoundError(
-                f"Model path '{path}' not found and no models available in '{pattern}'"
+                f"Model path '{path}' not found and no models available in '{pattern}'. "
+                "Please upload an RVC model to /content/drive/MyDrive/models/RVC/",
             )
         if use_ui and len(candidates) > 1:
-            print("Available models:")
-            for idx, model in enumerate(candidates, 1):
-                print(f"{idx}: {model}")
-            choice = input("Select model number: ")
-            try:
-                idx = int(choice) - 1
-                path = candidates[idx]
-            except (ValueError, IndexError):
-                raise FileNotFoundError(f"Invalid selection '{choice}'")
+            path = _select_model(candidates)
         else:
             path = candidates[0]
     logging.info("Using model: %s", path)


### PR DESCRIPTION
## Summary
- support automatic discovery of RVC models under `/content/drive/MyDrive/models/RVC/`
- interactive selection via notebook dropdown, environment variable or CLI argument
- document default model location and switching options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689690288338833082ef255728228401