### PR TITLE
feat: unify loudness and true peak measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Launch the Colab notebook via the badge above and run all cells:
 1. Installs dependencies (ffmpeg, PyTorch, the library).
 2. Generates short sine-wave stems and mixes them using `scripts/mix_cli.py`.
 
-After execution `mix.wav`, `mix_lufs.txt` and `report.json` appear in the notebook's working directory.
+After execution `mix.wav`, `mix_lufs.txt`, `report.json` and `processing.json` appear in the notebook's working directory. The JSON reports store loudness and true‑peak values measured with ffmpeg's `loudnorm` filter (ITU‑R BS.1770).
 
 ## UI Usage
 


### PR DESCRIPTION
## Summary
- measure loudness and true peak with ffmpeg loudnorm (BS.1770)
- store measurements in `report.json` and `processing.json`
- update tests and docs for unified measurement backend

## Testing
- `python -m pytest tests/smoke/test_mix.py -q` *(fails: FileNotFoundError: 'ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68969073acb883309c59dd440791a6d1