### PR TITLE
feat: add RVC model auto discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ notebook and batch scripts can invoke them in a consistent way:
 
 ```bash
 python scripts/pipeline.py --input INPUT_DIR --output OUTPUT_DIR \
-    --rvc_model MODEL.pth --f0_method rmvpe \
+    [--rvc_model MODEL.pth] --f0_method rmvpe \
     --quality_profile medium --lufs_target -14 \
     --truepeak_margin -1 --seed 0 --dry_run
 ```
@@ -81,7 +81,7 @@ Arguments:
 
 - `--input` – input file or directory.
 - `--output` – output directory.
-- `--rvc_model` – path to the RVC model.
+- `--rvc_model` – override path to the RVC model (defaults to auto discovery).
 - `--f0_method` – pitch extraction method.
 - `--quality_profile` – quality/speed trade‑off.
 - `--lufs_target` – target loudness in LUFS.

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -10,13 +10,14 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from mix import process
-from pipeline_common import build_parser
+from pipeline_common import build_parser, resolve_rvc_model
 from mix.deterministic import enable_determinism
 
 
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
+    resolve_rvc_model(args)
     if args.seed is not None:
         enable_determinism(args.seed)
     if args.dry_run:

--- a/scripts/pipeline_common.py
+++ b/scripts/pipeline_common.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 """Shared command-line interface for pipeline scripts."""
 import argparse
+import os
+
+from mix import model_manager
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -20,3 +23,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="set random seed and enable deterministic backends",
     )
     return parser
+
+
+def resolve_rvc_model(args):
+    """Populate ``args.rvc_model`` using CLI, env var and discovery.
+
+    A notebook dropdown is offered when multiple models are available.
+    """
+
+    def _in_notebook() -> bool:
+        try:
+            from IPython import get_ipython
+
+            return get_ipython() is not None
+        except Exception:  # pragma: no cover - IPython not installed
+            return False
+
+    path = model_manager.get_model_path(args.rvc_model, use_ui=_in_notebook())
+    os.environ[model_manager.ENV_VAR] = path
+    args.rvc_model = path
+    return args

--- a/scripts/pipeline_gdrive.py
+++ b/scripts/pipeline_gdrive.py
@@ -10,13 +10,14 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from mix import process
-from pipeline_common import build_parser
+from pipeline_common import build_parser, resolve_rvc_model
 from mix.deterministic import enable_determinism
 
 
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
+    resolve_rvc_model(args)
     if args.seed is not None:
         enable_determinism(args.seed)
     if args.dry_run:


### PR DESCRIPTION
## Summary
- resolve RVC models automatically via CLI flag, env var or notebook dropdown
- integrate auto-discovery into pipeline scripts
- document default model path and auto selection options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689695ce22e08330b27973e3c5f7c071